### PR TITLE
Update to version 0.2.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 mapping_cache.txt
 NC_cache.txt
 settings.json
+vkgl_conflicts_*
+vkgl_consensus_*

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -694,6 +694,9 @@ lovd_printIfVerbose(VERBOSITY_MEDIUM,
 if (!$bFound) {
     $bAccountsOK = false;
     $_CONFIG['user']['vkgl_generic_id'] = 0;
+} else {
+    // str_pad() the ID, so we can match it with what's in the DB.
+    $_CONFIG['user']['vkgl_generic_id'] = str_pad($_CONFIG['user']['vkgl_generic_id'], 5, '0', STR_PAD_LEFT);
 }
 
 // The other centers that we have collected from the input file.

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -1842,6 +1842,12 @@ foreach ($aData as $sVariant => $aVariant) {
                 $aVOGEntry['VariantOnGenome/Remarks_Non_Public'],
                 $aDataLOVD[$sLOVDKey]['VariantOnGenome/Remarks_Non_Public']
             );
+            // But still store the new ID, if not yet included.
+            foreach ($aVariant['id'] as $sNewID) {
+                if (!in_array($sNewID, $aVOGEntry['VariantOnGenome/Remarks_Non_Public']['ids'])) {
+                    $aVOGEntry['VariantOnGenome/Remarks_Non_Public']['ids'][] = $sNewID;
+                }
+            }
 
             // NOTE: This is debugging code. It checks the differences, and reports them, instead of running the update.
             if ($bDebug) {

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -15,7 +15,7 @@
  * Changelog   : 0.2    2019-11-07
  *               Better debugging, store the new VKGL IDs, improved diff
  *               formatting, better annotation of double submissions so we can
- *               remove them in the future.
+ *               remove them in the future, and now ignoring the HGVS column.
  *               0.1    2019-07-18
  *               Initial release.
  *
@@ -75,6 +75,7 @@ $_CONFIG = array(
     'columns_ignore' => array(
         // These are the columns that we'll ignore. If we find any others, we'll complain.
         'stop',
+        'hgvs',
         'consensus_classification',
         'matches',
         'disease',


### PR DESCRIPTION
Update to version 0.2.
- Improved comments and code around the position converter mapping code.
  - The functionality wasn't fully explained in comments, which made it a bit hard to understand.
  - The code could be simplified.
- Moved the debug flag up, and also don't add or delete data when it's active.
- Store new IDs when found.
  - VKGL changed all IDs, and I want to store all old and new IDs.
- When variants become single-lab submissions, the new `owned_by` field wasn't padded in the generated diff.
- Improved annotation of non-normalized variants which have their normalized counterparts in the database as well.
  - This makes it easier for us to remove these.
- Ignoring the HGVS column, as it isn't normalized anyway.
- Also updated the .gitignore file.
- Version bump to 0.2.
- Added changelog for version 0.2.