### PR TITLE
Released v0.7.

### DIFF
--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -2104,8 +2104,11 @@ foreach ($aData as $sVariant => $aVariant) {
                         // Or, the DNA changed because we fixed it, but the protein change is the same.
                         if (isset($aDiff['vots'][1][$nTranscriptID])
                             && $aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/DNA'] != $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/DNA']
-                            && $aLOVDVot['VariantOnTranscript/Protein'] == $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein']) {
+                            && ($aLOVDVot['VariantOnTranscript/Protein'] == $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein']
+                                || substr($aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/DNA'], -1) == '=')) {
                             $aLOVDVot['VariantOnTranscript/DNA'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/DNA'];
+                            $aLOVDVot['VariantOnTranscript/RNA'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'];
+                            $aLOVDVot['VariantOnTranscript/Protein'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein'];
                         }
                         // If the same, toss.
                         if (isset($aDiff['vots'][1][$nTranscriptID]) && $aLOVDVot == $aDiff['vots'][1][$nTranscriptID]) {

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -2089,7 +2089,9 @@ foreach ($aData as $sVariant => $aVariant) {
                             && in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', 'r.(?)', '-'))
                             && in_array($aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', 'r.(?)', 'r.spl?'))) {
                             $aLOVDVot['VariantOnTranscript/RNA'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'];
-                            if (in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'], array('p.(=)', '-'))) {
+                            if (in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'], array('p.(=)', '-'))
+                                || str_replace('*', 'Ter', $aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'])
+                                    == $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein']) {
                                 $aLOVDVot['VariantOnTranscript/Protein'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein'];
                             }
                         }

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -5,14 +5,14 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-06-27
- * Modified    : 2020-08-05
+ * Modified    : 2020-08-06
  * Version     : 0.6
  * For LOVD    : 3.0-22
  *
  * Purpose     : Processes the VKGL consensus data, and creates or updates the
  *               VKGL data in the LOVD instance.
  *
- * Changelog   : 0.6    2020-08-05
+ * Changelog   : 0.6    2020-08-06
  *               Conflicts are now reported while determining consensus
  *               classifications, so we can report them. When debugging, changes
  *               to the protein field are not easily reported anymore.
@@ -2089,7 +2089,7 @@ foreach ($aData as $sVariant => $aVariant) {
                             && in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', 'r.(?)', '-'))
                             && in_array($aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', 'r.(?)', 'r.spl?'))) {
                             $aLOVDVot['VariantOnTranscript/RNA'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'];
-                            if (in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'], array('p.(=)', '-'))
+                            if (in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'], array('p.(=)', 'p.?', '-'))
                                 || str_replace('*', 'Ter', $aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'])
                                     == $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein']) {
                                 $aLOVDVot['VariantOnTranscript/Protein'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/Protein'];

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -5,14 +5,17 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-06-27
- * Modified    : 2020-04-02
- * Version     : 0.5
+ * Modified    : 2020-08-05
+ * Version     : 0.6
  * For LOVD    : 3.0-22
  *
  * Purpose     : Processes the VKGL consensus data, and creates or updates the
  *               VKGL data in the LOVD instance.
  *
- * Changelog   : 0.5    2020-04-02
+ * Changelog   : 0.6    2020-08-05
+ *               Conflicts are now reported while determining consensus
+ *               classifications, so we can report them.
+ *               0.5    2020-04-02
  *               Improved variant validation error messages so they can be
  *               easily extracted from the output and reported to the centers.
  *               0.4    2020-03-23
@@ -76,7 +79,7 @@ if (isset($_SERVER['HTTP_HOST'])) {
 $bDebug = false; // Are we debugging? If so, none of the queries actually take place.
 $_CONFIG = array(
     'name' => 'VKGL data importer',
-    'version' => '0.5',
+    'version' => '0.6',
     'settings_file' => 'settings.json',
     'flags' => array(
         'y' => false,
@@ -1323,6 +1326,17 @@ foreach ($aData as $sVariant => $aVariant) {
             $aVariant['protein'] = array();
         }
         $aVariant['published_as'] = array($aVariant['published_as']);
+    }
+
+    // Report opposites.
+    if ($aVariant['status'] == 'opposite') {
+        lovd_printIfVerbose(VERBOSITY_MEDIUM,
+            ' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
+                    floor($nVariantsDone * 1000 / $nVariants) / 10, 1),
+                5, ' ', STR_PAD_LEFT) .
+            '%] Conflict: ' . implode(', ', array_map(function ($key, $val) { return $key . ': ' . $val; }, array_keys($aVariant['classifications']), $aVariant['classifications'])) . ' (' . implode(', ', array_unique($aVariant['gene'])) . ").\n" .
+            '                   IDs: ' . implode(', ', array_unique($aVariant['id'])) . ".\n" .
+            '                   DNA: ' . $aVariant['VariantOnGenome/DNA'] . "\n");
     }
 
     $aData[$sVariant] = $aVariant;

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -15,7 +15,8 @@
  * Changelog   : 0.6    2020-08-06
  *               Conflicts are now reported while determining consensus
  *               classifications, so we can report them. When debugging, changes
- *               to the protein field are not easily reported anymore.
+ *               caused by the new VV predictions (c.= transcript variants and
+ *               changes to the protein field) are not easily reported anymore.
  *               0.5    2020-04-02
  *               Improved variant validation error messages so they can be
  *               easily extracted from the output and reported to the centers.
@@ -1540,7 +1541,12 @@ foreach ($aData as $sVariant => $aVariant) {
         //  and we already did that stuff. Also, this code below is better in predicting good RNA values.
         // We will be borrowing quite some logic though. It would be better if this was solved.
         $aMapping['RNA'] = 'r.(?)'; // Default.
-        if (in_array($aMapping['protein'], array('', 'p.?', 'p.(=)'))) {
+        if ($aMapping['type'] == '=') {
+            $aMapping['RNA'] = 'r.(=)';
+            if (strpos($aMapping['protein'], '=') === false) {
+                $aMapping['protein'] = 'p.(=)';
+            }
+        } elseif (in_array($aMapping['protein'], array('', 'p.?', 'p.(=)'))) {
             // We'd want to check this.
             // Splicing.
             if (($aMapping['position_start_intron'] && abs($aMapping['position_start_intron']) <= 5)

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -14,7 +14,8 @@
  *
  * Changelog   : 0.6    2020-08-05
  *               Conflicts are now reported while determining consensus
- *               classifications, so we can report them.
+ *               classifications, so we can report them. When debugging, changes
+ *               to the protein field are not easily reported anymore.
  *               0.5    2020-04-02
  *               Improved variant validation error messages so they can be
  *               easily extracted from the output and reported to the centers.
@@ -2085,7 +2086,7 @@ foreach ($aData as $sVariant => $aVariant) {
                     foreach ($aDiff['vots'][0] as $nTranscriptID => $aLOVDVot) {
                         // Often the problem is that our RNA is better (and sometimes our Protein as well).
                         if (isset($aDiff['vots'][1][$nTranscriptID])
-                            && in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', '-'))
+                            && in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', 'r.(?)', '-'))
                             && in_array($aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'], array('r.(=)', 'r.(?)', 'r.spl?'))) {
                             $aLOVDVot['VariantOnTranscript/RNA'] = $aDiff['vots'][1][$nTranscriptID]['VariantOnTranscript/RNA'];
                             if (in_array($aDiff['vots'][0][$nTranscriptID]['VariantOnTranscript/Protein'], array('p.(=)', '-'))) {

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -5,14 +5,17 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-02
- * Modified    : 2020-07-03
- * Version     : 0.2
+ * Modified    : 2020-08-05
+ * Version     : 0.3
  * For LOVD    : 3.0-24
  *
  * Purpose     : Checks the NC cache and extends the mapping cache using the new
  *               Variant Validator object.
  *
- * Changelog   : 0.2    2020-07-03
+ * Changelog   : 0.3    2020-08-05
+ *               Receiving a VV mapping cache as an argument is now optional,
+ *               the way it was intended.
+ *               0.2    2020-07-03
  *               We can now receive a VV mapping cache through the arguments,
  *               which it will use instead of calls to VV. Also, we are now
  *               interactive, predicting when VV's mapping information is better
@@ -49,7 +52,7 @@ if (isset($_SERVER['HTTP_HOST'])) {
 // Default settings. We won't verify any setting, that's up to the process script.
 $_CONFIG = array(
     'name' => 'VKGL cache verification using Variant Validator',
-    'version' => '0.2',
+    'version' => '0.3',
     'settings_file' => 'settings.json',
     'VV_URL' => 'https://www35.lamp.le.ac.uk/', // Test instance with the latest LOVD endpoint. // www.variantvalidator.org.
     'user' => array(
@@ -242,8 +245,14 @@ $_CACHE = array();
 foreach (array('mutalyzer_cache_NC', 'mutalyzer_cache_mapping', 'mutalyzer_cache_mapping_VV') as $sKeyName) {
     $_CACHE[$sKeyName] = array();
     if ($sKeyName == 'mutalyzer_cache_mapping_VV') {
-        // This one we received through an argument.
-        $_CONFIG['user'][$sKeyName] = $aFiles[0];
+        // This one we received through an argument, optionally.
+        if ($aFiles) {
+            $_CONFIG['user'][$sKeyName] = $aFiles[0];
+        } else {
+            // Not received from user.
+            $_CACHE[$sKeyName] = array();
+            continue;
+        }
     }
     if (!file_exists($_CONFIG['user'][$sKeyName])
         || !is_file($_CONFIG['user'][$sKeyName]) || !is_readable($_CONFIG['user'][$sKeyName])) {

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -5,16 +5,17 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-02
- * Modified    : 2020-08-05
+ * Modified    : 2020-08-06
  * Version     : 0.3
  * For LOVD    : 3.0-24
  *
  * Purpose     : Checks the NC cache and extends the mapping cache using the new
  *               Variant Validator object.
  *
- * Changelog   : 0.3    2020-08-05
+ * Changelog   : 0.3    2020-08-06
  *               Receiving a VV mapping cache as an argument is now optional,
- *               the way it was intended.
+ *               the way it was intended. Also, fixed notices from variants that
+ *               caused a VV error.
  *               0.2    2020-07-03
  *               We can now receive a VV mapping cache through the arguments,
  *               which it will use instead of calls to VV. Also, we are now
@@ -399,7 +400,7 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
                     ' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
                         floor($nVariantsDone * 1000 / $nVariants) / 10, 1),
                         5, ' ', STR_PAD_LEFT) . '%] Error: Variant Validator error disagrees for variant ' . $sVariant . ".\n" .
-                    '                   {' . $sVariant . '|' . $sVariantCorrected . '|' . $aResult['data']['DNA'] . '|' . implode(';', $aResult['warnings']) . '|Error: Variant Validator error disagrees: ' . implode(';', $aResult['errors']) . '}' . "\n");
+                    '                   {' . $sVariant . '|' . $sVariantCorrected . '|(no results)|' . implode(';', $aResult['warnings']) . '|Error: Variant Validator error disagrees: ' . implode(';', $aResult['errors']) . '}' . "\n");
                 $nWarningsOccurred ++;
             }
             $nVariantsDone ++;


### PR DESCRIPTION
Released v0.7.
- Updated `process_VKGL_data.php` to v0.6:
  - Conflicts are now reported while determining consensus classifications.
  - When debugging, changes to the protein field are not easily reported anymore.
  - When debugging, ignore changes where VV wants to change the cDNA to c.=.

- Updated `verify_cache.php` to v0.3:
  - Receiving a VV mapping cache as an argument should be optional. The script was crashing if it wasn't passed.
  - Fixed notices that were caused by variants causing VV to return an error.