### PR TITLE
Release v.0.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,5 +4,8 @@ mapping_cache.*
 NC_cache.txt
 output_*
 settings.json
+stats.txt
+verification_*
 vkgl_consensus_*
+vkgl_errors_*
 vkgl_opposites_*

--- a/howto_report_errors_and_conflicts.txt
+++ b/howto_report_errors_and_conflicts.txt
@@ -1,0 +1,16 @@
+# Errors:
+grep "{" output_2021-02-08_full_run.txt | grep Error | tr '|' '\t' | cut -f 2- | sed 's/}$//' | sort -g > vkgl_errors_2021-02-09.txt
+
+# I then manually edited the file because the sorting is still wrong.
+# This was a lot of work, better sort by isolating the chromosomes first, sort them, then loop them and grep them
+#  and sort the results  with the first column removed?
+
+# Summary:
+cut -f 7 vkgl_errors_2021-02-09.txt | sort | uniq -c | sort -g
+
+
+
+# Conflicts:
+grep "{" output_2021-02-09_conflict_resolution_only.txt | grep Conflict | sort -g | tr '|' '\t' | cut -f 2- | sed 's/}$//' > vkgl_opposites_2021-02-09.txt
+
+# Again had to sort manually. See remark above.


### PR DESCRIPTION
Release v.0.9:
- Updated the formatting script; it can now handle duplicate entries (for centers with multiple files).
  - The VUMC center now delivers two files, and they have a small overlap.
  - Overlapping variants are reported.
  - When the classification doesn't match between two duplicates, they are both discarded.
  - Version bump to 0.1.4.
- Updated the processing script.
  - Conflicts are now reported in a structured manner, so we can easily filter them out of the run logs, and convert them automatically into a tab-delimited format to be reported to all the centers.
  - Version bump to 0.8.
- Added the first version of howto for creating error reports.
- Updated `.gitignore`.