### PR TITLE
Improve automation

### DIFF
--- a/copy_data_to_kg-web01.sh
+++ b/copy_data_to_kg-web01.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-echo "This will overwrite the remote caches. Are you sure?";
-read;
-
-rsync -av $(ls -1 /www/git/VKGL_import/vkgl_consensus_$(date +%Y-%m)* | grep -v chr1 | tr '\n' ' ') ifokkema@kg-web01:/home/ifokkema/git/VKGL_import/
-rsync -av /www/git/caches/NC_cache.txt /www/git/caches/mapping_cache.txt ifokkema@kg-web01:/home/ifokkema/git/caches/
+rsync -av $(ls -1 /www/git/VKGL_import/$(date +%Y-%m)/vkgl_consensus_* | tr '\n' ' ') "kg-web01:/home/${USER}/git/VKGL_import/"
 

--- a/copy_data_to_web01.sh
+++ b/copy_data_to_web01.sh
@@ -1,8 +1,4 @@
 #!/bin/bash
 
-echo "This will overwrite the remote caches. Are you sure?";
-read;
-
-rsync -av $(ls -1 /www/git/VKGL_import/vkgl_consensus_$(date +%Y-%m)* | grep -v chr1 | tr '\n' ' ') ifokkema@web01:/home/ifokkema/git/VKGL_import/
-rsync -av /www/git/caches/NC_cache.txt /www/git/caches/mapping_cache.txt ifokkema@web01:/home/ifokkema/git/caches/
+rsync -av $(ls -1 /www/git/VKGL_import/$(date +%Y-%m)/vkgl_consensus_* | tr '\n' ' ') "web01:/home/${USER}/git/VKGL_import/"
 

--- a/fetch_data_from_kg-web01.sh
+++ b/fetch_data_from_kg-web01.sh
@@ -67,3 +67,18 @@ do
         fi;
     fi;
 done;
+
+
+
+# Check if we have everything.
+DIFF=$(diff <(echo -e "amc.txt\nerasmus.txt\nlumc.txt\nnki.txt\nradboud_mumc.txt\numcg.txt\numcu.txt\nvumc.txt") <(cd "${DIR}"; ls -1) | grep -v "^[0-9>]");
+if [ "${DIFF}" ];
+then
+    echo "$(date '+%Y-%m-%d %H:%M:%S')    One or more data files are missing:" >> "${LOG}";
+    echo "${DIFF}" | sed 's/^</                      /' >> "${LOG}";
+    exit 5;
+fi;
+
+# If we get here, we have what we need. We will also have more (status.log, alissa.tar.gz), but that's OK.
+# Adding this file also signals to the next step, that we're ready.
+echo "$(date '+%Y-%m-%d %H:%M:%S') OK All files are ready, ready for the next step." >> "${LOG}";

--- a/fetch_data_from_kg-web01.sh
+++ b/fetch_data_from_kg-web01.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+
+# Created  : 2023-03-12
+# Modified : 2023-03-12
+
+# This will check if we have the data ready on kg-web01.
+
+DIR="$(dirname $0)/$(date +%Y-%m)";
+HOST="kg-web01";
+REMOTE="/home/${USER}/git/VKGL_export/$(date +%Y)/$(date +%Y-%m)";
+LOG="${DIR}/status.log";
+
+if [ ! -d "${DIR}" ];
+then
+    mkdir "${DIR}";
+fi;
+
+echo "" >> "${LOG}";
+echo "$(date '+%Y-%m-%d %H:%M:%S')    Checking for remote files..." >> "${LOG}";
+
+FILES=$(ssh ${HOST} ls "${REMOTE}" | grep -E "^(alissa.tar.gz|lumc.txt.gz|radboud_mumc.txt.gz)$");
+if [ "$(echo "${FILES}" | wc -l)" -eq "0" ];
+then
+    # If there's nothing to do, just die here.
+    echo "$(date '+%Y-%m-%d %H:%M:%S')    No remote files found (after filtering)." >> "${LOG}";
+    exit 1;
+fi;
+
+# Only download what we don't have already.
+for FILE in $FILES;
+do
+    if [ ! -f "${DIR}/${FILE}" ] && [ ! -f "$(echo "${DIR}/${FILE}" | sed 's/\.gz$//')" ];
+    then
+        # We don't have the file.
+        echo "$(date '+%Y-%m-%d %H:%M:%S')    Downloading ${FILE}..." >> "${LOG}";
+        rsync -aq "${HOST}:${REMOTE}/${FILE}" "${DIR}" >> "${LOG}" 2>&1;
+        if [ "$?" -ne "0" ];
+        then
+            echo "$(date '+%Y-%m-%d %H:%M:%S')    Download failed." >> "${LOG}";
+            exit 2;
+        fi;
+        echo "$(date '+%Y-%m-%d %H:%M:%S')    Success." >> "${LOG}";
+
+        # Extract the data.
+        if [ "$(echo "$FILE" | grep -E "\.(tar.gz|tgz)$")" ];
+        then
+            echo "$(date '+%Y-%m-%d %H:%M:%S')    Extracting tarball..." >> "${LOG}";
+            # Note that -C doesn't affect -f.
+            tar -C "${DIR}" -zxf "${DIR}/${FILE}" >> "${LOG}" 2>&1;
+            if [ "$?" -ne "0" ];
+            then
+                echo "$(date '+%Y-%m-%d %H:%M:%S')    Extract failed." >> "${LOG}";
+                exit 3;
+            fi;
+            echo "$(date '+%Y-%m-%d %H:%M:%S')    Success." >> "${LOG}";
+
+        elif [ "$(echo "$FILE" | grep "\.gz$")" ]
+        then
+            echo "$(date '+%Y-%m-%d %H:%M:%S')    Unzipping..." >> "${LOG}";
+            unpigz "${DIR}/${FILE}" >> "${LOG}" 2>&1;
+            if [ "$?" -ne "0" ];
+            then
+                echo "$(date '+%Y-%m-%d %H:%M:%S')    Extract failed." >> "${LOG}";
+                exit 4;
+            fi;
+            echo "$(date '+%Y-%m-%d %H:%M:%S')    Success." >> "${LOG}";
+        fi;
+    fi;
+done;

--- a/fetch_data_from_kg-web01.sh
+++ b/fetch_data_from_kg-web01.sh
@@ -18,7 +18,7 @@ fi;
 echo "" >> "${LOG}";
 echo "$(date '+%Y-%m-%d %H:%M:%S')    Checking for remote files..." >> "${LOG}";
 
-FILES=$(ssh ${HOST} ls "${REMOTE}" | grep -E "^(alissa.tar.gz|lumc.txt.gz|radboud_mumc.txt.gz)$");
+FILES=$(ssh ${HOST} ls "${REMOTE}" | grep -E "^(alissa.tar|lumc.txt|radboud_mumc.txt)\.gz$");
 if [ "$(echo "${FILES}" | wc -l)" -eq "0" ];
 then
     # If there's nothing to do, just die here.

--- a/fetch_data_from_kg-web01.sh
+++ b/fetch_data_from_kg-web01.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-# Created  : 2023-03-12
-# Modified : 2023-03-12
+# Created  : 2023-07-12
+# Modified : 2023-07-13
 
 # This will check if we have the data ready on kg-web01.
 
@@ -14,6 +14,15 @@ if [ ! -d "${DIR}" ];
 then
     mkdir "${DIR}";
 fi;
+
+# If the log indicates we were done before, then we don't have to do anything.
+if [ "$(grep " OK " "${LOG}" | wc -l)" -gt "0" ];
+then
+    # We're done already. If they really want to re-run, we should either introduce a -f, or the log should be emptied.
+    exit 0;
+fi;
+
+
 
 echo "" >> "${LOG}";
 echo "$(date '+%Y-%m-%d %H:%M:%S')    Checking for remote files..." >> "${LOG}";
@@ -80,5 +89,5 @@ then
 fi;
 
 # If we get here, we have what we need. We will also have more (status.log, alissa.tar.gz), but that's OK.
-# Adding this file also signals to the next step, that we're ready.
+# Adding this line also signals to the next step, that we're ready.
 echo "$(date '+%Y-%m-%d %H:%M:%S') OK All files are ready, ready for the next step." >> "${LOG}";

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -16,7 +16,8 @@
  *               Added a dry run flag (the old $bDebug variable), so that we can
  *               control debugging when invoking the script, enabling automation
  *               of the whole workflow. Also, fixed string offsets; curly braces
- *               are no longer supported.
+ *               are no longer supported. Updated the script to allow running it
+ *               from any directory other than the project's directory.
  *               1.0     2023-04-17
  *               Updated all PDO queries to the new q() method, now that our
  *               LOVD3 code has been updated. Otherwise, the script refuses to
@@ -103,11 +104,14 @@ if (isset($_SERVER['HTTP_HOST'])) {
     die('Please run this script through the command line.' . "\n");
 }
 
+// We're already using ROOT_PATH to point to LOVD, so define CWD to point to the directory where this script resides.
+define('CWD', dirname(__FILE__) . '/');
+
 // Default settings. Everything in 'user' will be verified with the user, and stored in settings.json.
 $_CONFIG = array(
     'name' => 'VKGL data importer',
     'version' => '1.1',
-    'settings_file' => 'settings.json',
+    'settings_file' => CWD . 'settings.json',
     'flags' => array(
         'n' => false, // Dry run.
         'y' => false, // Yes; accept current settings and don't ask anything.
@@ -154,8 +158,8 @@ $_CONFIG = array(
         // Variables we will be asking the user.
         'refseq_build' => 'hg19',
         'lovd_path' => '/www/databases.lovd.nl/shared/',
-        'mutalyzer_cache_NC' => 'NC_cache.txt', // Stores NC g. descriptions and their corrected output.
-        'mutalyzer_cache_mapping' => 'mapping_cache.txt', // Stores NC to NM mappings and the protein predictions.
+        'mutalyzer_cache_NC' => CWD . 'NC_cache.txt', // Stores NC g. descriptions and their corrected output.
+        'mutalyzer_cache_mapping' => CWD . 'mapping_cache.txt', // Stores NC to NM mappings and the protein predictions.
         'vkgl_generic_id' => 0, // The LOVD ID of the generic VKGL account, needed for single lab submissions.
         'public_singlelab_owners' => 'y', // Should single-lab submissions get a public owner?
         'delete_redundant_variants' => 'n', // Should we remove variants in LOVD no longer in the dataset?

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -15,7 +15,8 @@
  * Changelog   : 1.1     2023-07-14
  *               Added a dry run flag (the old $bDebug variable), so that we can
  *               control debugging when invoking the script, enabling automation
- *               of the whole workflow.
+ *               of the whole workflow. Also, fixed string offsets; curly braces
+ *               are no longer supported.
  *               1.0     2023-04-17
  *               Updated all PDO queries to the new q() method, now that our
  *               LOVD3 code has been updated. Otherwise, the script refuses to
@@ -240,7 +241,7 @@ function lovd_getVariantDescription (&$aVariant, $sRef, $sAlt)
     $sAltOriginal = $sAlt;
 
     // 'Eat' letters from either end - first left, then right - to isolate the difference.
-    while (strlen($sRef) > 0 && strlen($sAlt) > 0 && $sRef{0} == $sAlt{0}) {
+    while (strlen($sRef) > 0 && strlen($sAlt) > 0 && $sRef[0] == $sAlt[0]) {
         $sRef = substr($sRef, 1);
         $sAlt = substr($sAlt, 1);
         $aVariant['position_g_start'] ++;
@@ -972,7 +973,7 @@ foreach ($aData as $nKey => $aVariant) {
         $sVariantCorrected = $_CACHE['mutalyzer_cache_NC'][$sVariant];
 
         // Check if this is not a cached error message.
-        if ($sVariantCorrected{0} == '{') {
+        if ($sVariantCorrected[0] == '{') {
             // This is a cached error message. Report, but don't cache.
             $aError = json_decode($sVariantCorrected, true);
 
@@ -1796,7 +1797,7 @@ foreach ($aData as $sVariant => $aVariant) {
                 $sVariantCorrected = $_CACHE['mutalyzer_cache_NC'][$sLOVDVariant];
 
                 // Check if this is a cached error message.
-                if ($sVariantCorrected{0} == '{') {
+                if ($sVariantCorrected[0] == '{') {
                     // Variant is actually in error. These are OK to be removed, since we don't want them.
                     // If the variant is still in the source, that's OK, because he will be skipped there, too.
                     $bRemoveVariant = true;

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -5,14 +5,18 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-06-27
- * Modified    : 2023-04-18
- * Version     : 1.0
+ * Modified    : 2023-07-14
+ * Version     : 1.1
  * For LOVD    : 3.0-26
  *
  * Purpose     : Processes the VKGL consensus data, and creates or updates the
  *               VKGL data in the LOVD instance.
  *
- * Changelog   : 1.0     2023-04-17
+ * Changelog   : 1.1     2023-07-14
+ *               Added a dry run flag (the old $bDebug variable), so that we can
+ *               control debugging when invoking the script, enabling automation
+ *               of the whole workflow.
+ *               1.0     2023-04-17
  *               Updated all PDO queries to the new q() method, now that our
  *               LOVD3 code has been updated. Otherwise, the script refuses to
  *               function.
@@ -20,7 +24,6 @@
  *               Improved HGVS check.
  *               Updated 2023-04-18
  *               Handle some notices that sometimes show up in LOVD+.
- *               Also, 
  *               0.9     2022-05-09
  *               The JSON will no longer reports differences to transcript
  *               mappings when in reality, only the effectid changed. Also the
@@ -93,7 +96,6 @@
 //         If you fix this, remove "numberConversion" as a method from the cache, so all variants will be repeated.
 //         Perhaps VV can help here, it may provide more mappings and surely is a lot faster.
 // FIXME: Fix conflicts if on different genes, they can be regarded as non-conflicts.
-// FIXME: We are not seeing EREF errors in case of deletions, and they do happen. So we let incorrect variants through.
 
 // Command line only.
 if (isset($_SERVER['HTTP_HOST'])) {
@@ -101,13 +103,13 @@ if (isset($_SERVER['HTTP_HOST'])) {
 }
 
 // Default settings. Everything in 'user' will be verified with the user, and stored in settings.json.
-$bDebug = false; // Are we debugging? If so, none of the queries actually take place.
 $_CONFIG = array(
     'name' => 'VKGL data importer',
-    'version' => '1.0',
+    'version' => '1.1',
     'settings_file' => 'settings.json',
     'flags' => array(
-        'y' => false,
+        'n' => false, // Dry run.
+        'y' => false, // Yes; accept current settings and don't ask anything.
     ),
     'columns_mandatory' => array(
         // These are the columns that need to be present in order for the file to get processed.
@@ -506,8 +508,12 @@ $bCron = (empty($_SERVER['REMOTE_ADDR']) && empty($_SERVER['TERM']));
 define('VERBOSITY', ($bCron? 5 : 7));
 $tStart = time() + date('Z', 0); // Correct for timezone, otherwise the start value is not 0.
 
+// Configure dry run.
+$bDebug = !empty($_CONFIG['flags']['n']);
+
 lovd_printIfVerbose(VERBOSITY_MEDIUM,
-    $_CONFIG['name'] . ' v' . $_CONFIG['version'] . '.' . "\n");
+    $_CONFIG['name'] . ' v' . $_CONFIG['version'] . '.' . "\n" .
+    (!$bDebug? '' : '  Dry run enabled, not running any database updates.' . "\n"));
 
 
 

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -6,16 +6,18 @@
  *
  * Created     : 2020-04-02
  * Modified    : 2023-07-14
- * Version     : 0.4
+ * Version     : 0.5
  * For LOVD    : 3.0-24
  *
  * Purpose     : Checks the NC cache and extends the mapping cache using the new
  *               Variant Validator object.
  *
- * Changelog   : 0.4     2022-05-09
- *               Reduce the output by ignoring VV's peculiar p.(*123=) notation.
- *               Updated 2023-07-14
+ * Changelog   : 0.5     2023-07-14
+ *               When running non-interactively, through cron, don't ask the
+ *               user any questions; just dump all the differences and continue.
  *               Fixed string offset; curly braces are no longer supported.
+ *               0.4     2022-05-09
+ *               Reduce the output by ignoring VV's peculiar p.(*123=) notation.
  *               0.3     2020-08-06
  *               Receiving a VV mapping cache as an argument is now optional,
  *               the way it was intended. Also, fixed notices from variants that
@@ -54,11 +56,14 @@ if (isset($_SERVER['HTTP_HOST'])) {
     die('Please run this script through the command line.' . "\n");
 }
 
+// We're already using ROOT_PATH to point to LOVD, so define CWD to point to the directory where this script resides.
+define('CWD', dirname(__FILE__) . '/');
+
 // Default settings. We won't verify any setting, that's up to the process script.
 $_CONFIG = array(
     'name' => 'VKGL cache verification using Variant Validator',
-    'version' => '0.3',
-    'settings_file' => 'settings.json',
+    'version' => '0.5',
+    'settings_file' => CWD . 'settings.json',
     'VV_URL' => 'https://rest.variantvalidator.org/',
     'user' => array(
         // We don't have defaults, we load everything from the settings file.
@@ -166,7 +171,8 @@ define('VERBOSITY', ($bCron? 5 : 7));
 $tStart = time() + date('Z', 0); // Correct for timezone, otherwise the start value is not 0.
 
 lovd_printIfVerbose(VERBOSITY_MEDIUM,
-    $_CONFIG['name'] . ' v' . $_CONFIG['version'] . '.' . "\n");
+    $_CONFIG['name'] . ' v' . $_CONFIG['version'] . '.' . "\n" .
+    (!$bCron? '' : ' Detected non-interactive run through cron; repressing questions.' . "\n"));
 
 
 
@@ -426,6 +432,7 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
         // Now loop through the mappings we got from VV, and see if we can
         //  extend/update the current mapping cache.
         // We'll store all mappings, since we don't know which ones we want.
+        $bDifferences = false; // So we know if something was different (important for non-interactive mode).
         foreach ($aResult['data']['transcript_mappings'] as $sRefSeq => $aMapping) {
             // Is this one of those empty mappings from VV?
             if (empty($aMapping['DNA'])) {
@@ -559,6 +566,7 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
 
             if ($_CACHE['mutalyzer_cache_mapping'][$sVariantCorrected][$sRefSeq] != $aMapping) {
                 // Something is still different.
+                $bDifferences = true;
                 // Ask user which one to pick.
                 print(' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
                         floor($nVariantsDone * 1000 / $nVariants) / 10, 1),
@@ -569,6 +577,14 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
                         : $_CACHE['mutalyzer_cache_mapping'][$sVariantCorrected][$sRefSeq]['p']) . "\n" .
                     '                   Validator: ' . $aMapping['c'] . ' / ' .
                     (!isset($aMapping['p'])? '-' : $aMapping['p']) . "\n");
+
+                // If run non-interactively, bail out.
+                if ($bCron) {
+                    // We can't ask the user anything. Treat this mapping as skipped,
+                    //  but do continue to the next mapping; we want to see all mappings of this variant.
+                    print('                   Running non-interactively, skipping question.' . "\n");
+                    continue;
+                }
 
                 while (true) {
                     print('                 (M/V/s) [V]: ');
@@ -589,6 +605,12 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
                     }
                 }
             }
+        }
+
+        // If we are running non-interactively, and there were differences, don't store this.
+        if ($bCron && $bDifferences) {
+            // We never asked the user what they want, so don't store anything.
+            continue;
         }
 
         // Add our method to the list as well, so we won't repeat this.

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -5,28 +5,30 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-02
- * Modified    : 2022-05-09
+ * Modified    : 2023-07-14
  * Version     : 0.4
  * For LOVD    : 3.0-24
  *
  * Purpose     : Checks the NC cache and extends the mapping cache using the new
  *               Variant Validator object.
  *
- * Changelog   : 0.4    2022-05-09
+ * Changelog   : 0.4     2022-05-09
  *               Reduce the output by ignoring VV's peculiar p.(*123=) notation.
- *               0.3    2020-08-06
+ *               Updated 2023-07-14
+ *               Fixed string offset; curly braces are no longer supported.
+ *               0.3     2020-08-06
  *               Receiving a VV mapping cache as an argument is now optional,
  *               the way it was intended. Also, fixed notices from variants that
  *               caused a VV error.
- *               0.2    2020-07-03
+ *               0.2     2020-07-03
  *               We can now receive a VV mapping cache through the arguments,
  *               which it will use instead of calls to VV. Also, we are now
  *               interactive, predicting when VV's mapping information is better
  *               than Mutalyzer's, but asking when it's not sure.
- *               0.1    2020-04-03
+ *               0.1     2020-04-03
  *               Initial release.
  *
- * Copyright   : 2004-2020 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2023 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -312,7 +314,7 @@ $nAPICallsReported = 0;
 $nSecondsWaiting = 0; // Will be reset now and then.
 foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
     // Skip the header.
-    if ($sVariant{0} == '#') {
+    if ($sVariant[0] == '#') {
         continue;
     }
     // Also skip EREF errors. We know VV handles them well, but because these


### PR DESCRIPTION
### Improve automation
To shorten the time needed to run the VKGL imports even further, improve automation.
- Add a script that fetches all data from kg-web01. It searches for a fixes set of files, downloads them, extracts them, and finally, checks if we have everything. If so, this is indicated in the log file, which prevents us from running again this month.
- Update the VKGL data processor.
  - Add a dry run option. This allows us to call it automatically to update the caches without running actual updates in the database.
  - Allow running the script from any directory.
  - Update string offset notations.
  - Version bump to 1.1.
- Update the cache verification script.
  - When verifying the cache through cron, don't ask any questions. Just dump all the differences and continue.
  - Update string offset notation.
  - Version bump to 0.5.
- Update the bash scripts that push the data to the remote servers.
  - The new cache synching script takes over part of the work.
  - Also, it's better to leave the user out now.