### PR TITLE
Fix the pipeline after the April run

### DIFF
--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -5,13 +5,16 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-11-13
- * Modified    : 2025-02-07
+ * Modified    : 2025-05-01
  * Version     : 0.2.0
  *
  * Purpose     : Parses the VKGL center's raw data files (of different formats)
  *               and creates one consensus data file which can then be processed
  *               by the process_VKGL_data.php script.
  *
+ * Changelog   : 0.2.1  2025-05-01
+ *               Added more variant types to lovd_HGVStoVCF();
+ *               deletion-insertions and inversions.
  * Changelog   : 0.2.0  2025-02-07
  *               Re-implement the storage of variants and the filtering of
  *               duplicates completely. We were losing variants when only a
@@ -48,7 +51,7 @@
  *               0.1.0  2019-11-14
  *               Initial release.
  *
- * Copyright   : 2004-2024 Leiden University Medical Center; http://www.LUMC.nl/
+ * Copyright   : 2004-2025 Leiden University Medical Center; http://www.LUMC.nl/
  * Programmer  : Ivo F.A.C. Fokkema <I.F.A.C.Fokkema@LUMC.nl>
  *
  *
@@ -78,7 +81,7 @@ if (isset($_SERVER['HTTP_HOST'])) {
 $bDebug = false; // Are we debugging? If so, none of the queries actually take place.
 $_CONFIG = array(
     'name' => 'VKGL raw data formatter',
-    'version' => '0.2.0',
+    'version' => '0.2.1',
     'settings_file' => 'settings.json',
     'flags' => array(
         'y' => false,
@@ -184,6 +187,16 @@ function lovd_HGVStoVCF ($sVariant) {
             $aVCF['ref'] = str_repeat('N', ($aRegs[3] - $aRegs[1] + 1));
         }
 
+    } elseif (preg_match('/^g.([0-9]+)(_([0-9]+))?delins([A-Z]+)$/', $sVariant, $aRegs)) {
+        // Deletion-insertions.
+        $aVCF['pos'] = $aRegs[1];
+        if (empty($aRegs[2])) {
+            $aVCF['ref'] = 'N';
+        } else {
+            $aVCF['ref'] = str_repeat('N', ($aRegs[3] - $aRegs[1] + 1));
+        }
+        $aVCF['alt'] = $aRegs[4];
+
     } elseif (preg_match('/^g.([0-9]+)(_([0-9]+))?dup$/', $sVariant, $aRegs)) {
         // Duplications.
         $aVCF['pos'] = $aRegs[1];
@@ -201,6 +214,12 @@ function lovd_HGVStoVCF ($sVariant) {
         $aVCF['pos'] = $aRegs[1];
         $aVCF['ref'] = 'N';
         $aVCF['alt'] = 'N' . $aRegs[2];
+
+    } elseif (preg_match('/^g.([0-9]+)_([0-9]+)inv$/', $sVariant, $aRegs)) {
+        // Inversions.
+        $aVCF['pos'] = $aRegs[1];
+        $aVCF['ref'] = str_repeat('N', ($aRegs[2] - $aRegs[1]) + 1);
+        $aVCF['alt'] = $aVCF['ref'];
 
     } else {
         return false;

--- a/generate_reports.sh
+++ b/generate_reports.sh
@@ -37,13 +37,13 @@ echo "Created vkgl_opposites_${DATE}.log.";
 # All stats can be fetched from the last run.
 DATA=$(grep -EA4 "\[(100.0%|Totals)\]" output.03.full-run-with-deletes.log)
 echo "
-Unique variants received : $(echo "$DATA" | grep "VKGL file successfully parsed," | sed 's/^ *//' | cut -d \  -f 8) (after filtering out internal conflicts)
+Unique variants received : $(echo "$DATA" | grep "VKGL file successfully parsed," | sed 's/^ *//' | cut -d \  -f 8) (after filtering out most internal conflicts)
 Unique variants in error : $(echo "$DATA" | grep "Variants lost:" | sed 's/^ *//' | cut -d \  -f 3 | cut -d . -f 1)    -
 Unique variants merged   : $(echo "$DATA" | grep "variants merged. Variants left:" | sed 's/^ *//' | cut -d \  -f 3)  -
                            ======
 Unique variants left     : $(echo "$DATA" | grep "variants merged. Variants left:" | sed 's/^ *//' | cut -d \  -f 8 | cut -d . -f 1)
                            ======
-$(echo "$DATA" | grep -A 3 "Single-lab" | sed 's/^        //')
+$(echo "$DATA" | grep -A 3 "Single-lab" | sed 's/^        //')    (including the last internal conflicts)
 =================================
 Total classifications    : $(echo "$DATA" | tail | grep " Variants " | grep -v "deleted" | cut -b 20- | cut -d : -f 2- | sed 's/\.$//' | paste -sd+ | bc)
                            ======

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -12,7 +12,8 @@
  *               VKGL data in the LOVD instance.
  *
  * Changelog   : 1.3     2025-05-02
- *               Handle WT variants that we're now receiving.
+ *               Handle WT variants that we're now receiving, and add more error
+ *               messages to the NC cache.
  *               1.2     2024-09-17
  *               Improved the script by re-using more LOVD code, removing custom
  *               built code. Also solved errors showing up when processing the
@@ -923,7 +924,7 @@ foreach ($aData as $nKey => $aVariant) {
             $aError = array();
             if (!empty($aResult['errors']) && isset($aResult['messages'])) {
                 foreach ($aResult['messages'] as $aMessage) {
-                    if (isset($aMessage['errorcode']) && in_array($aMessage['errorcode'], array('ERANGE', 'EREF'))) {
+                    if (isset($aMessage['errorcode'])) {
                         // Cache this error.
                         $aError[$aMessage['errorcode']] = $aMessage['message'];
                     }
@@ -1126,7 +1127,7 @@ foreach ($aData as $sVariant => $aVariant) {
                     // Rules: report opposites; */VUS to VUS; LB/B to LB; LP/P to LP.
                     if ((isset($aClassifications['B']) || isset($aClassifications['LB']))
                         && (isset($aClassifications['P']) || isset($aClassifications['LP']))) {
-                        // Internal conflict within center.
+                        // Internal conflict within center. These are reported in the opposites file.
                         lovd_printIfVerbose(VERBOSITY_MEDIUM,
                             ' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
                                 floor($nVariantsDone * 1000 / $nVariants) / 10, 1),

--- a/process_VKGL_data.php
+++ b/process_VKGL_data.php
@@ -5,14 +5,15 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-06-27
- * Modified    : 2024-09-17
- * Version     : 1.2
- * For LOVD    : 3.0-30
+ * Modified    : 2025-05-02
+ * Version     : 1.3
  *
  * Purpose     : Processes the VKGL consensus data, and creates or updates the
  *               VKGL data in the LOVD instance.
  *
- * Changelog   : 1.2     2024-09-17
+ * Changelog   : 1.3     2025-05-02
+ *               Handle WT variants that we're now receiving.
+ *               1.2     2024-09-17
  *               Improved the script by re-using more LOVD code, removing custom
  *               built code. Also solved errors showing up when processing the
  *               data on LOVD+ and when processing very long variants. From now
@@ -117,7 +118,7 @@ define('CWD', dirname(__FILE__) . '/');
 // Default settings. Everything in 'user' will be verified with the user, and stored in settings.json.
 $_CONFIG = array(
     'name' => 'VKGL data importer',
-    'version' => '1.2',
+    'version' => '1.3',
     'settings_file' => CWD . 'settings.json',
     'flags' => array(
         'n' => false, // Dry run.
@@ -895,7 +896,27 @@ foreach ($aData as $nKey => $aVariant) {
 
     // Update cache if needed.
     if ($bUpdateCache) {
-        $aResult = json_decode(file_get_contents($_CONFIG['mutalyzer_URL'] . '/json/runMutalyzerLight?variant=' . $sVariant), true);
+        // Hold on; is this a WT variant? If so, Mutalyzer doesn't handle that.
+        // Plus, we don't have to check its description.
+        $aResult = [];
+        if (substr($sVariant, -1) == '=') {
+            // Well, OK, don't blindly accept it, double-check.
+            $aLOVD = json_decode(file_get_contents('https://api.lovd.nl/v2/checkHGVS/' . rawurlencode($sVariant)), true);
+            if ($aLOVD && !$aLOVD['errors'] && $aLOVD['data'][0]['corrected_values']) {
+                // Fake a successful Mutalyzer result.
+                $aResult = [
+                    'genomicDescription' => key($aLOVD['data'][0]['corrected_values']),
+                    'legend' => [], // No transcripts; we'll use VV.
+                    'transcriptDescriptions' => [], // No mappings; we'll use VV.
+                    'proteinDescriptions' => [], // No mappings; we'll use VV.
+                ];
+            }
+        }
+
+        if (!$aResult) {
+            // Call Mutalyzer only when we didn't call our own tool yet.
+            $aResult = json_decode(file_get_contents($_CONFIG['mutalyzer_URL'] . '/json/runMutalyzerLight?variant=' . $sVariant), true);
+        }
         if (!$aResult || !isset($aResult['genomicDescription'])) {
             // Error? Just report. They must be new variants, anyway.
             // If this is a recognized Mutalyzer error, we want to cache this as well, so we won't keep running into it.

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -316,7 +316,7 @@ else
     echo "${OUTPUT}" | sed "s/^/                       /" >> "${LOG}";
     echo "$(date '+%Y-%m-%d %H:%M:%S') OK Successfully copied the data to Web01." >> "${LOG}";
 
-    OUTPUT=$(../copy_data_to_kg.sh 2>&1);
+    OUTPUT=$(../copy_data_to_kg-web01.sh 2>&1);
     if [ $? -ne 0 ];
     then
         # This failed.

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -5,14 +5,15 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2020-04-02
- * Modified    : 2024-08-29
- * Version     : 0.6
- * For LOVD    : 3.0-24
+ * Modified    : 2025-05-05
+ * Version     : 0.7
  *
  * Purpose     : Checks the NC cache and extends the mapping cache using the new
  *               Variant Validator object.
  *
- * Changelog   : 0.6     2024-08-29
+ * Changelog   : 0.7     2025-05-05
+ *               Skip all Mutalyzer errors to prevent issues.
+ *               0.6     2024-08-29
  *               Also detect when run through the pipeline script; treat this as
  *               if we're being run by Cron.
  *               0.5     2023-07-14
@@ -65,7 +66,7 @@ define('CWD', dirname(__FILE__) . '/');
 // Default settings. We won't verify any setting, that's up to the process script.
 $_CONFIG = array(
     'name' => 'VKGL cache verification using Variant Validator',
-    'version' => '0.6',
+    'version' => '0.7',
     'settings_file' => CWD . 'settings.json',
     'VV_URL' => 'https://rest.variantvalidator.org/',
     'user' => array(
@@ -330,9 +331,8 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
     if ($sVariant[0] == '#') {
         continue;
     }
-    // Also skip EREF errors. We know VV handles them well, but because these
-    //  are not in the mapping cache, we keep resending them to VV.
-    if (in_array(substr($sVariantCorrected, 0, 8), array('{"EREF":', '{"ERANGE', 'null'))) {
+    // Also skip Mutalyzer errors. This prevents issues with variants being resent to VV all the time.
+    if (substr($sVariantCorrected, 0, 2) != 'NC') {
         $nVariantsDone ++;
         continue; // Next variant.
     }

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -12,7 +12,8 @@
  *               Variant Validator object.
  *
  * Changelog   : 0.7     2025-05-05
- *               Skip all Mutalyzer errors to prevent issues.
+ *               Skip all Mutalyzer errors to prevent issues and handle chrM:g
+ *               issues.
  *               0.6     2024-08-29
  *               Also detect when run through the pipeline script; treat this as
  *               if we're being run by Cron.
@@ -409,7 +410,9 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
                 // Errors match.
                 unset($aResult['errors']['ESYNTAX']);
             }
-            if ($aResult['errors']) {
+            // Ignore issues with chrM:g variants that we created ourselves by error when processing the Franklin data.
+            if ($aResult['errors']
+                && !(count($aResult['errors']) == 1 && str_contains($aResult['errors'][0], 'For NC_012920.1, please use (m).'))) {
                 // Assume errors mismatch, catch these errors and fix when we run into them.
                 // For now, VV fails on ERANGE errors, so we won't get here (yet).
                 // This happens when VV throws an error that Mutalyzer didn't.

--- a/verify_cache.php
+++ b/verify_cache.php
@@ -13,7 +13,7 @@
  *
  * Changelog   : 0.7     2025-05-05
  *               Skip all Mutalyzer errors to prevent issues and handle chrM:g
- *               issues.
+ *               issues. Also improve the debugging output.
  *               0.6     2024-08-29
  *               Also detect when run through the pipeline script; treat this as
  *               if we're being run by Cron.
@@ -351,6 +351,12 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
 
     // Update cache if needed.
     if ($bUpdateCache) {
+        // Prepare for debugging, in case it's needed.
+        $aDebugging = [
+            'input' => $sVariant,
+            'corrected_mutalyzer' => $sVariantCorrected,
+        ];
+
         // If we've been passed a mapping cache with VV annotations, use that to
         //  update the existing cache. This will save us a lot of time.
         if (isset($_CACHE['mutalyzer_cache_mapping_VV'][$sVariantCorrected])
@@ -376,16 +382,18 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
         } else {
             $tStartWait = microtime(true);
             // Call VV, don't limit to certain transcripts, we don't know which ones we'll want.
+            // Send the *original* variants, so we can double-check the outcome.
             $aResult = $_VV->verifyGenomicAndPredictProtein($sVariant);
             $nSecondsWaiting += (microtime(true) - $tStartWait);
             $nAPICalls ++;
             if (!$aResult) {
                 // Strange, VV failed completely for this variant.
+                $aDebugging['message'] = 'Error: Variant Validator failed.';
                 lovd_printIfVerbose(VERBOSITY_MEDIUM,
                     ' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
                         floor($nVariantsDone * 1000 / $nVariants) / 10, 1),
                         5, ' ', STR_PAD_LEFT) . '%] Error: Variant Validator failed for variant ' . $sVariant . ".\n" .
-                    '                   {' . $sVariant . '|' . $sVariantCorrected . '|FALSE||Error: Variant Validator failed.}' . "\n");
+                    preg_replace('/(^|\n)/', '$1                   ', json_encode($aDebugging, JSON_PRETTY_PRINT)) . "\n");
                 $nWarningsOccurred ++;
                 $nVariantsDone ++;
                 continue; // Next variant.
@@ -394,6 +402,11 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
 
         // If VV complains that the variant description has been corrected, we ignore this.
         unset($aResult['warnings']['WCORRECTED']);
+        $aDebugging += [
+            'corrected_VV' => ($aResult['data']['DNA'] ?? '(no results)'),
+            'errors_VV' => ($aResult['errors'] ?? []),
+            'warnings_VV' => ($aResult['warnings'] ?? []),
+        ];
 
         // If VV throws an error, at least make sure Mutalyzer has the same error.
         if ($aResult['errors']) {
@@ -416,11 +429,12 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
                 // Assume errors mismatch, catch these errors and fix when we run into them.
                 // For now, VV fails on ERANGE errors, so we won't get here (yet).
                 // This happens when VV throws an error that Mutalyzer didn't.
+                $aDebugging['message'] = 'Error: Variant Validator error disagrees.';
                 lovd_printIfVerbose(VERBOSITY_MEDIUM,
                     ' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
                         floor($nVariantsDone * 1000 / $nVariants) / 10, 1),
                         5, ' ', STR_PAD_LEFT) . '%] Error: Variant Validator error disagrees for variant ' . $sVariant . ".\n" .
-                    '                   {' . $sVariant . '|' . $sVariantCorrected . '|(no results)|' . implode(';', $aResult['warnings']) . '|Error: Variant Validator error disagrees: ' . implode(';', $aResult['errors']) . '}' . "\n");
+                    preg_replace('/(^|\n)/', '$1                   ', json_encode($aDebugging, JSON_PRETTY_PRINT)) . "\n");
                 $nWarningsOccurred ++;
             }
             $nVariantsDone ++;
@@ -428,11 +442,12 @@ foreach ($_CACHE['mutalyzer_cache_NC'] as $sVariant => $sVariantCorrected) {
 
         } elseif ($aResult['data']['DNA'] != $sVariantCorrected) {
             // Variant threw no error, but Variant Validator disagrees with Mutalyzer.
+            $aDebugging['message'] = 'Error: Variant predictors disagree.';
             lovd_printIfVerbose(VERBOSITY_MEDIUM,
                 ' ' . date('H:i:s', time() - $tStart) . ' [' . str_pad(number_format(
                     floor($nVariantsDone * 1000 / $nVariants) / 10, 1),
                     5, ' ', STR_PAD_LEFT) . '%] Error: Variant predictors disagree for variant ' . $sVariant . ".\n" .
-                '                   {' . $sVariant . '|' . $sVariantCorrected . '|' . $aResult['data']['DNA'] . '|' . implode(';', $aResult['warnings']) . '|Error: Variant predictors disagree.}' . "\n");
+                preg_replace('/(^|\n)/', '$1                   ', json_encode($aDebugging, JSON_PRETTY_PRINT)) . "\n");
             $nWarningsOccurred ++;
             $nVariantsDone ++;
             continue; // Next variant.


### PR DESCRIPTION
### Fix the pipeline after the April run
- Formatter:
  - Added more variant types to the formatting script. We are now seeing deletion-insertions and an inversion in the data from Leiden. The pipeline failed during the formatting because these variant types weren't configured in `lovd_HGVStoVCF()`.
- Processor:
  - Handle WT variants that we're now receiving.
  - Log more errors in the NC cache. Wildtype variants didn't log any error but still were rejected. Make sure that we log every error, so we can actually see what's going on. This seems to also apply to variants with Ns in them.
- Cache verification:
  - Skip all variants with Mutalyzer errors. They will most likely all cause issues.
  - Properly handle `chrM:g` variants. We failed them because VV throws an error where while Mutalyzer does not.
  - Improve the output for debugging. Multiple variables were dumped on the screen without further annotation, and this got confusing all the time.
- Pipeline:
  - Fix typo in script name.
  - Update comments after recent changes.