### PR TITLE
Add support for the NKI JSON format.

### DIFF
--- a/fetch_data_from_kg-web01.sh
+++ b/fetch_data_from_kg-web01.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Created  : 2023-07-12
-# Modified : 2024-08-28
+# Modified : 2025-09-19
 
 # This will check if we have the data ready on kg-web01.
 
@@ -84,7 +84,7 @@ done;
 
 
 # Check if we have everything.
-DIFF=$(diff <(echo -e "amc.txt\nerasmus.txt\nlumc.txt\nnki.txt\nradboud_mumc.txt\numcg.txt\numcu.txt\nvumc.txt") <(cd "${DIR}"; ls -1) | grep -v "^[0-9>-]");
+DIFF=$(diff <(echo -e "amc.txt\nerasmus.txt\nlumc.txt\nnki.json\nnki.txt\nradboud_mumc.txt\numcg.txt\numcu.txt\nvumc.txt") <(cd "${DIR}"; ls -1) | grep -v "^[0-9>-]");
 if [ "${DIFF}" ];
 then
     echo "$(date '+%Y-%m-%d %H:%M:%S')    One or more data files are missing:" >> "${LOG}";

--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -5,7 +5,7 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-11-13
- * Modified    : 2025-09-19
+ * Modified    : 2025-09-25
  * Version     : 0.2.3
  *
  * Purpose     : Parses the VKGL center's raw data files (of different formats)
@@ -566,6 +566,33 @@ foreach ($aFiles as $sFile => $sCenter) {
             )
         );
     }
+
+
+
+    if (strrchr($sFile, '.') == '.json') {
+        // The simplest way is to convert the JSON data into TSV data and then throw that into the parser.
+        // It means the TSV gets created and then parsed again, but that's fine for now.
+        // We should later probably handle this in a better (OOP) way, but for now, this works just fine.
+
+        // Parse the JSON data. Let's keep this simple.
+        $aJSON = json_decode(implode($aLines), true);
+        if (!$aJSON) {
+            lovd_printIfVerbose(VERBOSITY_LOW,
+                'Error: Can not parse file:' . $sFile . ".\n\n");
+            die(EXIT_ERROR_INPUT_CANT_OPEN);
+        }
+
+        // The keys of this array should all be numeric; it should be an array of objects.
+        if (array_filter(array_keys($aJSON), 'is_string') || !is_array(current($aJSON))
+            || !array_filter(array_keys(current($aJSON)), 'is_string')) {
+            // String keys in this array, first child is not an array, or first child does not have string keys.
+            lovd_printIfVerbose(VERBOSITY_LOW,
+                'Error: JSON data is not an array of objects:' . $sFile . ".\n\n");
+            die(EXIT_ERROR_INPUT_CANT_OPEN);
+        }
+    }
+
+
 
     // First line should be headers.
     $aHeaders = explode("\t", strtolower(array_shift($aLines)));

--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -449,8 +449,11 @@ $nCentersFound = 0;
 
 foreach ($aFiles as $nKey => $sFile) {
     list($sName, $sExt) = explode('.', basename($sFile), 2);
-    $aCentersFound[] = $sName;
-    $nCentersFound ++;
+    // Allow multiple files per center.
+    if (!in_array($sName, $aCentersFound)) {
+        $aCentersFound[] = $sName;
+        $nCentersFound ++;
+    }
 
     // Make file key in array, so we can store metadata.
     $aFiles[$sFile] = $sName;
@@ -894,9 +897,11 @@ foreach ($aFiles as $sFile => $sCenter) {
         }
     }
 
-    // Also add center to headers for output.
-    $_CONFIG['columns_mandatory'][] = $sCenter;
-    $_CONFIG['columns_mandatory'][] = $sCenter . $_CONFIG['columns_center_suffix'];
+    // Also add center to headers for output, as long as it's not there already.
+    if (!in_array($sCenter, $_CONFIG['columns_mandatory'])) {
+        $_CONFIG['columns_mandatory'][] = $sCenter;
+        $_CONFIG['columns_mandatory'][] = $sCenter . $_CONFIG['columns_center_suffix'];
+    }
 
     lovd_printIfVerbose(VERBOSITY_MEDIUM,
         ' ' . date('H:i:s', time() - $tStart) . ' [' .

--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -5,8 +5,8 @@
  * LEIDEN OPEN VARIATION DATABASE (LOVD)
  *
  * Created     : 2019-11-13
- * Modified    : 2025-08-11
- * Version     : 0.2.2
+ * Modified    : 2025-09-19
+ * Version     : 0.2.3
  *
  * Purpose     : Parses the VKGL center's raw data files (of different formats)
  *               and creates one consensus data file which can then be processed
@@ -84,7 +84,7 @@ if (isset($_SERVER['HTTP_HOST'])) {
 $bDebug = false; // Are we debugging? If so, none of the queries actually take place.
 $_CONFIG = array(
     'name' => 'VKGL raw data formatter',
-    'version' => '0.2.2',
+    'version' => '0.2.3',
     'settings_file' => 'settings.json',
     'flags' => array(
         'y' => false,
@@ -534,11 +534,10 @@ foreach ($aFiles as $sFile => $sCenter) {
 
     $aHeaders = array();
     $nHeaders = 0;
-    $nLine = 0;
     $sFileType = '';
 
-    $fInput = fopen($sFile, 'r');
-    if ($fInput === false) {
+    $aLines = file($sFile, FILE_IGNORE_NEW_LINES | FILE_SKIP_EMPTY_LINES);
+    if (!$aLines) {
         lovd_printIfVerbose(VERBOSITY_LOW,
             'Error: Can not open file:' . $sFile . ".\n\n");
         die(EXIT_ERROR_INPUT_CANT_OPEN);
@@ -547,35 +546,29 @@ foreach ($aFiles as $sFile => $sCenter) {
     // The Radboud data doesn't have a header :(
     if ($sCenter == 'radboud_mumc') {
         // Invent the header.
-        $sLine = implode("\t", array(
-            'chromosome',
-            'start',
-            'stop',
-            'ref',
-            'alt',
-            'gene',
-            'transcript_or_dna',
-            'empty',
-            'empty',
-            'location',
-            'empty',
-            'classification',
-        ));
-
-    } else {
-        // Loop through data until we get a header.
-        while ($sLine = fgets($fInput)) {
-            $nLine++;
-            $sLine = strtolower(rtrim($sLine));
-            if (!$sLine) {
-                continue;
-            }
-            break;
-        }
+        array_unshift(
+            $aLines,
+            implode("\t",
+                [
+                    'chromosome',
+                    'start',
+                    'stop',
+                    'ref',
+                    'alt',
+                    'gene',
+                    'transcript_or_dna',
+                    'empty',
+                    'empty',
+                    'location',
+                    'empty',
+                    'classification',
+                ]
+            )
+        );
     }
 
     // First line should be headers.
-    $aHeaders = explode("\t", $sLine);
+    $aHeaders = explode("\t", strtolower(array_shift($aLines)));
     $nHeaders = count($aHeaders);
     $aHeaders = array_map('trim', $aHeaders, array_fill(0, $nHeaders, '"'));
 
@@ -600,14 +593,9 @@ foreach ($aFiles as $sFile => $sCenter) {
 
 
 
-    while ($sLine = fgets($fInput)) {
+    foreach ($aLines as $nLine => $sLine) {
         $nLine++;
-        $sLine = rtrim($sLine);
-        if (!$sLine) {
-            continue;
-        }
-
-        $aDataLine = explode("\t", $sLine);
+        $aDataLine = explode("\t", rtrim($sLine));
         // Trim quotes off of the data.
         $aDataLine = array_map(function($sData) {
             return trim($sData, '"');

--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -103,19 +103,23 @@ $_CONFIG = array(
     ),
     'columns_center_suffix' => '_link', // This is how we recognize a center, because it also has a *_link column.
     'header_signatures' => array(
-        'alt;c;c_nomen;chromosome;classification;effect;exon;gene;id;last_updated_by;last_updated_on;location;p_nomen;' .
-            'ref;start;stop;timestamp;transcript;variant_type' => 'alissa',
-        'alt;c_nomen;chromosome;classification;effect;exon;gene;id;last_updated_by;last_updated_on;location;p_nomen;' .
-            'ref;start;stop;timestamp;transcript;variant_type' => 'alissa',
-        'alt;alt_orig;c_nomen;chrom;chromosome;classification;effect;exon;gene;hgvs_normalized_vkgl;id;' .
-            'last_updated_by;last_updated_on;location;p_nomen;pos;ref;ref_orig;significance;start;stop;timestamp;' .
-            'transcript;type;variant_type' => 'alissa2',
-        'alt;c;c_nomen;chromosome;classification;effect;exon;gene;last_updated_by;last_updated_on;location;p_nomen;' .
-            'ref;start;stop;transcript;variant_type' => 'alissa', // Apparently, Groningen used to edit the files and added the id and timestamp fields. Alissa files from the SFTP server don't have those fields.
-        'alt;c_nomen;chromosome;classification;effect;exon;gene;last_updated_by;last_updated_on;location;p_nomen;' .
-            'ref;start;stop;transcript;variant_type' => 'alissa', // 2024-02 + 2024-04; Due to a personnel change at Alissa without a proper handover, manual exports are being generated with yet another signature.
+        // Alissa:
+        'alt;c;c_nomen;chromosome;classification;effect;exon;gene;id;last_updated_by;last_updated_on;location;p_nomen;ref;start;stop;timestamp;transcript;variant_type' => 'alissa',
+        'alt;c_nomen;chromosome;classification;effect;exon;gene;id;last_updated_by;last_updated_on;location;p_nomen;ref;start;stop;timestamp;transcript;variant_type' => 'alissa',
+        'alt;alt_orig;c_nomen;chrom;chromosome;classification;effect;exon;gene;hgvs_normalized_vkgl;id;last_updated_by;last_updated_on;location;p_nomen;pos;ref;ref_orig;significance;start;stop;timestamp;transcript;type;variant_type' => 'alissa2',
+        // Apparently, Groningen used to edit the files and added the id and timestamp fields. Alissa files from the SFTP server don't have those fields.
+        'alt;c;c_nomen;chromosome;classification;effect;exon;gene;last_updated_by;last_updated_on;location;p_nomen;ref;start;stop;transcript;variant_type' => 'alissa',
+        // 2024-02 + 2024-04; Due to a personnel change at Alissa without a proper handover, manual exports are being generated with yet another signature.
+        'alt;c_nomen;chromosome;classification;effect;exon;gene;last_updated_by;last_updated_on;location;p_nomen;ref;start;stop;transcript;variant_type' => 'alissa',
+
+        // LUMC:
         'cdna;chromosome;gdna_normalized;geneid;protein;refseq_build;variant_effect' => 'lumc',
+
+        // Radboud/MUMC+:
         'alt;chromosome;classification;empty;empty;empty;gene;location;ref;start;stop;transcript_or_dna' => 'radboud',
+
+        // Parsed JSON formats:
+        'alt;annotation;build;cdna;chromosome;classification;gene;position;protein;ref;transcript' => 'JSON',
     ),
     'header_signatures_JSON' => array(
         '_id;alternative;build;cNomen;category;chromosome;classification;date;description;display_id;effect;end;exon;gene_symbol;institute;location;maintainer;managed_variant_id;pNomen;position;reference;sub_category;type;variant_id;variant_info' => 'nki',
@@ -849,6 +853,23 @@ foreach ($aFiles as $sFile => $sCenter) {
                             'pathogenic',
                         ), strtolower($aDataLine['classification'])),
                     $sCenter . $_CONFIG['columns_center_suffix'] => $aDataLine['classification'],
+                );
+                break;
+
+            case 'JSON':
+                $sVariantKey = implode('|', array(
+                    $aDataLine['chromosome'],
+                    $aDataLine['position'],
+                    $aDataLine['ref'],
+                    $aDataLine['alt'],
+                    $aDataLine['gene'],
+                    $aDataLine['transcript'],
+                    $aDataLine['cdna'],
+                ));
+                $aValues = array(
+                    'protein' => $aDataLine['protein'],
+                    $sCenter => $aDataLine['classification'],
+                    $sCenter . $_CONFIG['columns_center_suffix'] => $aDataLine['annotation'],
                 );
                 break;
         }

--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -117,6 +117,9 @@ $_CONFIG = array(
         'cdna;chromosome;gdna_normalized;geneid;protein;refseq_build;variant_effect' => 'lumc',
         'alt;chromosome;classification;empty;empty;empty;gene;location;ref;start;stop;transcript_or_dna' => 'radboud',
     ),
+    'header_signatures_JSON' => array(
+        '_id;alternative;build;cNomen;category;chromosome;classification;date;description;display_id;effect;end;exon;gene_symbol;institute;location;maintainer;managed_variant_id;pNomen;position;reference;sub_category;type;variant_id;variant_info' => 'nki',
+    ),
     'mutalyzer_URL' => 'https://v2.mutalyzer.nl/',
     'user' => array(
         // Variables we will be asking the user.
@@ -589,6 +592,68 @@ foreach ($aFiles as $sFile => $sCenter) {
             lovd_printIfVerbose(VERBOSITY_LOW,
                 'Error: JSON data is not an array of objects:' . $sFile . ".\n\n");
             die(EXIT_ERROR_INPUT_CANT_OPEN);
+        }
+
+        // OK, now collect the signature and figure out what format this is.
+        $aSignature = array_keys(current($aJSON));
+        sort($aSignature);
+        $sHeaderSignature = implode(';', $aSignature);
+        if (!isset($_CONFIG['header_signatures_JSON'][$sHeaderSignature])) {
+            lovd_printIfVerbose(VERBOSITY_LOW,
+                'Error: File does not conform to any known JSON format: ' . $sFile . ".\n({$sHeaderSignature})\n\n");
+            die(EXIT_ERROR_HEADER_FIELDS_INCORRECT);
+        } else {
+            $sFileType = $_CONFIG['header_signatures_JSON'][$sHeaderSignature];
+        }
+
+        // Build the header first, then loop the data and build the data file.
+        $aLines = [
+            implode("\t",
+                [
+                    'build',
+                    'chromosome',
+                    'position',
+                    'ref',
+                    'alt',
+                    'gene',
+                    'transcript',
+                    'cDNA',
+                    'protein',
+                    'classification',
+                    'annotation',
+                ]
+            )
+        ];
+        foreach ($aJSON as $aVariant) {
+            switch ($sFileType) {
+                case 'nki':
+                    $aVariant['classification'] = strtolower($aVariant['classification']);
+
+                    // Skip artefacts.
+                    if ($aVariant['classification'] == 'artefact') {
+                        continue 2;
+                    }
+
+                    // Build the data array. Keys aren't used, but it's useful for readability.
+                    $aLine = [
+                        'build' => 'GRCh' . $aVariant['build'],
+                        'chromosome' => $aVariant['chromosome'],
+                        'position' => $aVariant['position'],
+                        'ref' => $aVariant['reference'],
+                        'alt' => $aVariant['alternative'],
+                        'gene' => $aVariant['gene_symbol']['hgnc_symbol'],
+                        // I found two examples where the primary transcript had a different cDNA description than the
+                        //  MANE transcript, and that the cDNA description matched the primary transcript.
+                        //  So we'll use that.
+                        'transcript' => $aVariant['gene_symbol']['primary_transcripts'][0],
+                        'cDNA' => $aVariant['cNomen'],
+                        'protein' => $aVariant['pNomen'],
+                        'classification' => str_replace('vous', 'VUS', $aVariant['classification']),
+                        'annotation' => implode(',', $aVariant['maintainer']),
+                    ];
+                    $aLines[] = implode("\t", $aLine);
+                    break;
+            }
         }
     }
 

--- a/format_raw_VKGL_files.php
+++ b/format_raw_VKGL_files.php
@@ -12,7 +12,10 @@
  *               and creates one consensus data file which can then be processed
  *               by the process_VKGL_data.php script.
  *
- * Changelog   : 0.2.2  2025-08-11
+ * Changelog   : 0.2.3  2025-09-25
+ *               Allow processing JSON files, too. Currently, we only support
+ *               the JSON data from the NKI.
+ *               0.2.2  2025-08-11
  *               Allow for genomic variants starting with "m."; this is normal
  *               for mitochondrial genes.
  *             : 0.2.1  2025-05-01

--- a/run_pipeline.sh
+++ b/run_pipeline.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # Created  : 2023-10-10
-# Modified : 2024-10-04
+# Modified : 2025-09-25
 
 # Because the crontab got too complex, better make this a script.
 
@@ -79,7 +79,7 @@ then
     echo "$(date '+%Y-%m-%d %H:%M:%S')    Formatting and grouping the files..." >> "${LOG}";
     tail -n 1 "${LOG}";
     # Also pipe STDERR to the log file so we can catch what went wrong.
-    ../format_raw_VKGL_files.php *.txt -y > "${OUTFILE}" 2>&1;
+    ../format_raw_VKGL_files.php *.txt *.json -y > "${OUTFILE}" 2>&1;
     if [ $? -ne 0 ];
     then
         # This failed.


### PR DESCRIPTION
### Add support for the NKI JSON format.
- Expect an `nki.json` file before starting the data processing.
- Read files in one go, preparing for JSON input. JSON can't be read line by line, so make sure we handle this differently so we'll be able to handle TSV as well as JSON data.
- Catch JSON files based on their extension and check them. They need to be an array of objects.
- Recognize the NKI format and convert it into a TSV format. This TSV format is then fed into the TSV parser. Not the most efficient way of doing things, but it works for now.
- Recognize the TSV data from JSON files, and process it.
- Allow multiple data input files per center. The NKI JSON file does not contain all the data that was also in the old TSV file. So I'm keeping both.
- Add the changelog and instruct the formatter to parse JSON, too.